### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://sede-sandbox.visualstudio.com/173c12c2-2839-444c-aa23-a3f3506e161a/81bce877-efb9-4f74-b109-2f341491d74b/_apis/work/boardbadge/0a14dca1-16c7-40cc-9527-88949952a6fd)](https://sede-sandbox.visualstudio.com/173c12c2-2839-444c-aa23-a3f3506e161a/_boards/board/t/81bce877-efb9-4f74-b109-2f341491d74b/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#41134. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.